### PR TITLE
Refactor Mission Crew List View Model

### DIFF
--- a/[11] Moonshot/Moonshot/Views/Mission/Crew List/MissionCrewListView.swift
+++ b/[11] Moonshot/Moonshot/Views/Mission/Crew List/MissionCrewListView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct MissionCrewListView: View {
 	
-	@ObservedObject
+	@EnvironmentObject
 	var viewModel: MissionCrewListViewModel
 	
     var body: some View {
@@ -72,9 +72,11 @@ struct MissionCrewListView_Previews: PreviewProvider {
 		mission: Missions.allMissions[0],
 		astronauts: Astronauts.allAstronauts
 	)
+	static private let missionCrewListVM = MissionCrewListViewModel(crew: missionViewModel.crew)
 	
     static var previews: some View {
-		MissionCrewListView(viewModel: MissionCrewListViewModel(parentVM: missionViewModel))
+		MissionCrewListView()
+			.environmentObject(missionCrewListVM)
 			.preferredColorScheme(.dark)
     }
 }

--- a/[11] Moonshot/Moonshot/Views/Mission/Crew List/MissionCrewListViewModel.swift
+++ b/[11] Moonshot/Moonshot/Views/Mission/Crew List/MissionCrewListViewModel.swift
@@ -7,19 +7,16 @@
 
 import Foundation
 
-/// Relies on its parent view model of type `MissionViewModel`,
-/// due to the way the original source JSON is structured:
-/// each Apollo mission's crew members is mapped to a
-/// corresponding astronauts name.
+/// Use this view model as an `@EnvironmentObject`,
+/// as its initializer requires a parameter of type `[CrewMember]`.
 ///
-/// I couldn't pass a mission object to its initializer, because its crew
-/// is of `Mission`\'s nested type `Crew`, and not compatible
-/// with `CrewMember` type
+/// Therefore, you would need its parent view to create this class's instance
+/// and pass an array of `CrewMember`\'s
 final class MissionCrewListViewModel: ObservableObject {
 	
 	let crew: [CrewMember]
 	
-	init(parentVM: MissionViewModel) {
-		self.crew = parentVM.crew
+	init(crew: [CrewMember]) {
+		self.crew = crew
 	}
 }

--- a/[11] Moonshot/Moonshot/Views/Mission/MissionView.swift
+++ b/[11] Moonshot/Moonshot/Views/Mission/MissionView.swift
@@ -36,12 +36,11 @@ struct MissionView: View {
 						maxWidth: geometry.size.width * 0.9
 					)
 					
-					MissionCrewListView(
-						viewModel: MissionCrewListViewModel(
-							parentVM: viewModel
+					MissionCrewListView()
+						.padding(.trailing)
+						.environmentObject(
+							MissionCrewListViewModel(crew: viewModel.crew)
 						)
-					)
-					.padding(.trailing)
 				}
 				.padding(.bottom)
 			}


### PR DESCRIPTION
# About
Previously, `MissionCrewListViewModel` has to know about its parentVM of type `MissionViewModel`.

With this pull request, now it's decoupled and only has to know about a `CrewMember`.