### PR TITLE
Add simple unit test for HomeVM

### DIFF
--- a/[17] Socialie/Socialie.xcodeproj/project.pbxproj
+++ b/[17] Socialie/Socialie.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		2C50F74328BFAA4600F15D4B /* URLSession+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C50F74228BFAA4600F15D4B /* URLSession+Ext.swift */; };
 		2C50F74628BFADD100F15D4B /* ApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C50F74528BFADD100F15D4B /* ApiService.swift */; };
 		2C50F74928BFAF4C00F15D4B /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C50F74828BFAF4C00F15D4B /* HomeViewModel.swift */; };
+		2C57D10328C67FA5005E7809 /* SocialieTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C57D10228C67FA5005E7809 /* SocialieTests.swift */; };
 		2C7D267C28BFCC5000B11C87 /* HomeGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7D267B28BFCC5000B11C87 /* HomeGridView.swift */; };
 		2C7D267E28BFD1D500B11C87 /* OnlineIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7D267D28BFD1D500B11C87 /* OnlineIndicator.swift */; };
 		2C7D268328BFE8CB00B11C87 /* HomeCellImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7D268228BFE8CB00B11C87 /* HomeCellImage.swift */; };
@@ -52,6 +53,16 @@
 		2CED777428C1372700A193D5 /* Calendar+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CED777328C1372700A193D5 /* Calendar+Ext.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		2C57D10428C67FA5005E7809 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2C50F72228BFA41100F15D4B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2C50F72928BFA41100F15D4B;
+			remoteInfo = Socialie;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		2C3B594B28C1ABCE00CAB1D2 /* UserDefaultsKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsKey.swift; sourceTree = "<group>"; };
 		2C3B594E28C1ABF000CAB1D2 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
@@ -69,6 +80,8 @@
 		2C50F74228BFAA4600F15D4B /* URLSession+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+Ext.swift"; sourceTree = "<group>"; };
 		2C50F74528BFADD100F15D4B /* ApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiService.swift; sourceTree = "<group>"; };
 		2C50F74828BFAF4C00F15D4B /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		2C57D10028C67FA5005E7809 /* SocialieTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SocialieTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C57D10228C67FA5005E7809 /* SocialieTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialieTests.swift; sourceTree = "<group>"; };
 		2C7D267B28BFCC5000B11C87 /* HomeGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGridView.swift; sourceTree = "<group>"; };
 		2C7D267D28BFD1D500B11C87 /* OnlineIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicator.swift; sourceTree = "<group>"; };
 		2C7D268228BFE8CB00B11C87 /* HomeCellImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellImage.swift; sourceTree = "<group>"; };
@@ -101,6 +114,13 @@
 
 /* Begin PBXFrameworksBuildPhase section */
 		2C50F72728BFA41100F15D4B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2C57D0FD28C67FA5005E7809 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -158,6 +178,7 @@
 			isa = PBXGroup;
 			children = (
 				2C50F72C28BFA41100F15D4B /* Socialie */,
+				2C57D10128C67FA5005E7809 /* SocialieTests */,
 				2C50F72B28BFA41100F15D4B /* Products */,
 			);
 			sourceTree = "<group>";
@@ -166,6 +187,7 @@
 			isa = PBXGroup;
 			children = (
 				2C50F72A28BFA41100F15D4B /* Socialie.app */,
+				2C57D10028C67FA5005E7809 /* SocialieTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -244,6 +266,14 @@
 				2C7D268628BFEDBE00B11C87 /* Other Views */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		2C57D10128C67FA5005E7809 /* SocialieTests */ = {
+			isa = PBXGroup;
+			children = (
+				2C57D10228C67FA5005E7809 /* SocialieTests.swift */,
+			);
+			path = SocialieTests;
 			sourceTree = "<group>";
 		};
 		2C7D267F28BFE35400B11C87 /* Cell Item */ = {
@@ -404,6 +434,24 @@
 			productReference = 2C50F72A28BFA41100F15D4B /* Socialie.app */;
 			productType = "com.apple.product-type.application";
 		};
+		2C57D0FF28C67FA5005E7809 /* SocialieTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2C57D10828C67FA5005E7809 /* Build configuration list for PBXNativeTarget "SocialieTests" */;
+			buildPhases = (
+				2C57D0FC28C67FA5005E7809 /* Sources */,
+				2C57D0FD28C67FA5005E7809 /* Frameworks */,
+				2C57D0FE28C67FA5005E7809 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2C57D10528C67FA5005E7809 /* PBXTargetDependency */,
+			);
+			name = SocialieTests;
+			productName = SocialieTests;
+			productReference = 2C57D10028C67FA5005E7809 /* SocialieTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -416,6 +464,10 @@
 				TargetAttributes = {
 					2C50F72928BFA41100F15D4B = {
 						CreatedOnToolsVersion = 13.4.1;
+					};
+					2C57D0FF28C67FA5005E7809 = {
+						CreatedOnToolsVersion = 13.4.1;
+						TestTargetID = 2C50F72928BFA41100F15D4B;
 					};
 				};
 			};
@@ -433,6 +485,7 @@
 			projectRoot = "";
 			targets = (
 				2C50F72928BFA41100F15D4B /* Socialie */,
+				2C57D0FF28C67FA5005E7809 /* SocialieTests */,
 			);
 		};
 /* End PBXProject section */
@@ -444,6 +497,13 @@
 			files = (
 				2C50F73528BFA41200F15D4B /* Preview Assets.xcassets in Resources */,
 				2C50F73228BFA41200F15D4B /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2C57D0FE28C67FA5005E7809 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -498,7 +558,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		2C57D0FC28C67FA5005E7809 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2C57D10328C67FA5005E7809 /* SocialieTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		2C57D10528C67FA5005E7809 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2C50F72928BFA41100F15D4B /* Socialie */;
+			targetProxy = 2C57D10428C67FA5005E7809 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		2C50F73628BFA41200F15D4B /* Debug */ = {
@@ -673,6 +749,42 @@
 			};
 			name = Release;
 		};
+		2C57D10628C67FA5005E7809 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8R3P49X4ZM;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.rungxanh1995.SocialieTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Socialie.app/Socialie";
+			};
+			name = Debug;
+		};
+		2C57D10728C67FA5005E7809 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 8R3P49X4ZM;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.github.rungxanh1995.SocialieTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Socialie.app/Socialie";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -690,6 +802,15 @@
 			buildConfigurations = (
 				2C50F73928BFA41200F15D4B /* Debug */,
 				2C50F73A28BFA41200F15D4B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2C57D10828C67FA5005E7809 /* Build configuration list for PBXNativeTarget "SocialieTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2C57D10628C67FA5005E7809 /* Debug */,
+				2C57D10728C67FA5005E7809 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/[17] Socialie/Socialie.xcodeproj/project.pbxproj
+++ b/[17] Socialie/Socialie.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		2C50F74328BFAA4600F15D4B /* URLSession+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C50F74228BFAA4600F15D4B /* URLSession+Ext.swift */; };
 		2C50F74628BFADD100F15D4B /* ApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C50F74528BFADD100F15D4B /* ApiService.swift */; };
 		2C50F74928BFAF4C00F15D4B /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C50F74828BFAF4C00F15D4B /* HomeViewModel.swift */; };
-		2C57D10328C67FA5005E7809 /* SocialieTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C57D10228C67FA5005E7809 /* SocialieTests.swift */; };
 		2C7D267C28BFCC5000B11C87 /* HomeGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7D267B28BFCC5000B11C87 /* HomeGridView.swift */; };
 		2C7D267E28BFD1D500B11C87 /* OnlineIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7D267D28BFD1D500B11C87 /* OnlineIndicator.swift */; };
 		2C7D268328BFE8CB00B11C87 /* HomeCellImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7D268228BFE8CB00B11C87 /* HomeCellImage.swift */; };
@@ -81,7 +80,6 @@
 		2C50F74528BFADD100F15D4B /* ApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiService.swift; sourceTree = "<group>"; };
 		2C50F74828BFAF4C00F15D4B /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		2C57D10028C67FA5005E7809 /* SocialieTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SocialieTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		2C57D10228C67FA5005E7809 /* SocialieTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialieTests.swift; sourceTree = "<group>"; };
 		2C7D267B28BFCC5000B11C87 /* HomeGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGridView.swift; sourceTree = "<group>"; };
 		2C7D267D28BFD1D500B11C87 /* OnlineIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicator.swift; sourceTree = "<group>"; };
 		2C7D268228BFE8CB00B11C87 /* HomeCellImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellImage.swift; sourceTree = "<group>"; };
@@ -271,7 +269,6 @@
 		2C57D10128C67FA5005E7809 /* SocialieTests */ = {
 			isa = PBXGroup;
 			children = (
-				2C57D10228C67FA5005E7809 /* SocialieTests.swift */,
 			);
 			path = SocialieTests;
 			sourceTree = "<group>";
@@ -562,7 +559,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2C57D10328C67FA5005E7809 /* SocialieTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/[17] Socialie/Socialie.xcodeproj/project.pbxproj
+++ b/[17] Socialie/Socialie.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		2C50F74328BFAA4600F15D4B /* URLSession+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C50F74228BFAA4600F15D4B /* URLSession+Ext.swift */; };
 		2C50F74628BFADD100F15D4B /* ApiService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C50F74528BFADD100F15D4B /* ApiService.swift */; };
 		2C50F74928BFAF4C00F15D4B /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C50F74828BFAF4C00F15D4B /* HomeViewModel.swift */; };
+		2C57D11028C68504005E7809 /* HomeVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C57D10F28C68504005E7809 /* HomeVMTests.swift */; };
+		2C57D11228C68560005E7809 /* MockDataCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C57D11128C68560005E7809 /* MockDataCoordinator.swift */; };
 		2C7D267C28BFCC5000B11C87 /* HomeGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7D267B28BFCC5000B11C87 /* HomeGridView.swift */; };
 		2C7D267E28BFD1D500B11C87 /* OnlineIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7D267D28BFD1D500B11C87 /* OnlineIndicator.swift */; };
 		2C7D268328BFE8CB00B11C87 /* HomeCellImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7D268228BFE8CB00B11C87 /* HomeCellImage.swift */; };
@@ -80,6 +82,8 @@
 		2C50F74528BFADD100F15D4B /* ApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiService.swift; sourceTree = "<group>"; };
 		2C50F74828BFAF4C00F15D4B /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		2C57D10028C67FA5005E7809 /* SocialieTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SocialieTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2C57D10F28C68504005E7809 /* HomeVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeVMTests.swift; sourceTree = "<group>"; };
+		2C57D11128C68560005E7809 /* MockDataCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataCoordinator.swift; sourceTree = "<group>"; };
 		2C7D267B28BFCC5000B11C87 /* HomeGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeGridView.swift; sourceTree = "<group>"; };
 		2C7D267D28BFD1D500B11C87 /* OnlineIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnlineIndicator.swift; sourceTree = "<group>"; };
 		2C7D268228BFE8CB00B11C87 /* HomeCellImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCellImage.swift; sourceTree = "<group>"; };
@@ -269,6 +273,8 @@
 		2C57D10128C67FA5005E7809 /* SocialieTests */ = {
 			isa = PBXGroup;
 			children = (
+				2C57D10F28C68504005E7809 /* HomeVMTests.swift */,
+				2C57D11128C68560005E7809 /* MockDataCoordinator.swift */,
 			);
 			path = SocialieTests;
 			sourceTree = "<group>";
@@ -464,6 +470,7 @@
 					};
 					2C57D0FF28C67FA5005E7809 = {
 						CreatedOnToolsVersion = 13.4.1;
+						LastSwiftMigration = 1340;
 						TestTargetID = 2C50F72928BFA41100F15D4B;
 					};
 				};
@@ -559,6 +566,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2C57D11228C68560005E7809 /* MockDataCoordinator.swift in Sources */,
+				2C57D11028C68504005E7809 /* HomeVMTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -749,14 +758,21 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 8R3P49X4ZM;
 				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.rungxanh1995.SocialieTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Socialie.app/Socialie";
@@ -767,10 +783,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 8R3P49X4ZM;
 				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.github.rungxanh1995.SocialieTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/[17] Socialie/Socialie.xcodeproj/xcshareddata/xcschemes/Socialie.xcscheme
+++ b/[17] Socialie/Socialie.xcodeproj/xcshareddata/xcschemes/Socialie.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2C50F72928BFA41100F15D4B"
+               BuildableName = "Socialie.app"
+               BlueprintName = "Socialie"
+               ReferencedContainer = "container:Socialie.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2C57D0FF28C67FA5005E7809"
+               BuildableName = "SocialieTests.xctest"
+               BlueprintName = "SocialieTests"
+               ReferencedContainer = "container:Socialie.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2C50F72928BFA41100F15D4B"
+            BuildableName = "Socialie.app"
+            BlueprintName = "Socialie"
+            ReferencedContainer = "container:Socialie.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2C50F72928BFA41100F15D4B"
+            BuildableName = "Socialie.app"
+            BlueprintName = "Socialie"
+            ReferencedContainer = "container:Socialie.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/[17] Socialie/Socialie/Data/DataCoordinator.swift
+++ b/[17] Socialie/Socialie/Data/DataCoordinator.swift
@@ -7,15 +7,24 @@
 
 import CoreData
 
+protocol DataCoordinator {
+	@MainActor
+	func updateCache(with fetchedUsers: [User]) -> Void
+	
+	func fetchCache() -> [CachedUser]
+	
+	func fetchData() async -> [User]
+}
+
 /// The coordinator of data from fetching decoded API data
 /// to caching them in persistence.
 ///
 /// This is the primary actor of the "scope creep" challenge
 /// of adding Core Data to Socialie.
-final class DataCoordinator {
+final class DataCoordinatorImpl: DataCoordinator {
 	
 	/// Singleton instance to use in the app
-	static let standard: DataCoordinator = .init()
+	static let standard: DataCoordinatorImpl = .init()
 	
 	private let apiService: ApiService
 	private let storageProvider: StorageProvider

--- a/[17] Socialie/Socialie/Views/Home View/HomeViewModel.swift
+++ b/[17] Socialie/Socialie/Views/Home View/HomeViewModel.swift
@@ -28,7 +28,7 @@ extension HomeView {
 		
 		private let dataCoordinator: DataCoordinator
 		
-		init(dataCoordinator: DataCoordinator = .standard) {
+		init(dataCoordinator: DataCoordinator = DataCoordinatorImpl.standard) {
 			self.dataCoordinator = dataCoordinator
 			cachedUsers = [CachedUser]()
 		}

--- a/[17] Socialie/SocialieTests/HomeVMTests.swift
+++ b/[17] Socialie/SocialieTests/HomeVMTests.swift
@@ -1,0 +1,24 @@
+//
+//  HomeVMTests.swift
+//  SocialieTests
+//
+//  Created by Joe Pham on 2022-09-05.
+//
+
+import XCTest
+@testable import Socialie
+
+final class HomeVMTests: XCTestCase {
+	
+	var vm: HomeView.ViewModel!
+	var mockDataCoord: MockDataCoordinator!
+	
+	override func setUp() {
+		mockDataCoord = .init()
+		vm = .init(dataCoordinator: mockDataCoord)
+	}
+	
+	func testDataFetchingOperationsShouldPass() async -> Void {
+		await vm.fetchData()
+	}
+}

--- a/[17] Socialie/SocialieTests/MockDataCoordinator.swift
+++ b/[17] Socialie/SocialieTests/MockDataCoordinator.swift
@@ -1,0 +1,26 @@
+//
+//  MockDataCoordinator.swift
+//  SocialieTests
+//
+//  Created by Joe Pham on 2022-09-05.
+//
+
+import Foundation
+@testable import Socialie
+
+final class MockDataCoordinator: DataCoordinator {
+	var users = [User]()
+	
+	@MainActor
+	func updateCache(with fetchedUsers: [User]) -> Void {
+		return
+	}
+	
+	func fetchCache() -> [CachedUser] {
+		return [CachedUser]()
+	}
+	
+	func fetchData() async -> [User] {
+		return users
+	}
+}


### PR DESCRIPTION
- First step into exploring unit testing in SwiftUI.
- Refactored the code a little bit in `DataCoordinator`, made it a protocol, and rename the original one to an implementation class